### PR TITLE
 Refactor status messages 

### DIFF
--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -2,13 +2,13 @@
 
 def call(String buildResult) {
 
-  if ( buildResult == "SUCCESS" ) {
+  if ( buildResult == "Success" ) {
     color = "good"
   }
-  else if( buildResult == "FAILURE" ) { 
+  else if( buildResult == "Failure" ) { 
     color = "danger"
   }
-  else if( buildResult == "UNSTABLE" ) { 
+  else if( buildResult == "Unstable" ) { 
     color = "warning"
   }
   else {

--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -16,6 +16,6 @@ def call(String buildResult) {
   }
 
 // Send notifications
-slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${env.BUILD_RESULT} after ${currentBuild.durationString} and counting (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
+slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${env.BUILD_RESULT} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
 
 }

--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -16,6 +16,6 @@ def call(String buildResult) {
   }
 
 // Send notifications
-  slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - "${buildResult} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
+  slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${buildResult} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
 
 }

--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -2,20 +2,24 @@
 
 def call(String buildResult) {
 
-  if ( buildResult == "Success" ) {
+  if ( buildResult == "SUCCESS" ) {
     color = "good"
+    status = "Success"
   }
-  else if( buildResult == "Failure" ) { 
+  else if( buildResult == "FAILURE" ) { 
     color = "danger"
+    status = "Failure"
   }
-  else if( buildResult == "Unstable" ) { 
+  else if( buildResult == "UNSTABLE" ) { 
     color = "warning"
+    status = "Unstable"
   }
   else {
     color = "danger"
+    status = "Unknown"
   }
 
 // Send notifications
-  slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${buildResult} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
+  slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${status} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
 
 }

--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -16,6 +16,6 @@ def call(String buildResult) {
   }
 
 // Send notifications
-slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${env.BUILD_RESULT} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
+  slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - "${buildResult} after ${currentBuild.durationString} (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
 
 }

--- a/vars/slackNotifier.groovy
+++ b/vars/slackNotifier.groovy
@@ -1,16 +1,21 @@
 #!/usr/bin/env groovy
 
 def call(String buildResult) {
+
   if ( buildResult == "SUCCESS" ) {
-    slackSend color: "good", message: "Job: ${env.JOB_NAME} with buildnumber ${env.BUILD_NUMBER} was successful"
+    color = "good"
   }
   else if( buildResult == "FAILURE" ) { 
-    slackSend color: "danger", message: "Job: ${env.JOB_NAME} with buildnumber ${env.BUILD_NUMBER} was failed"
+    color = "danger"
   }
   else if( buildResult == "UNSTABLE" ) { 
-    slackSend color: "warning", message: "Job: ${env.JOB_NAME} with buildnumber ${env.BUILD_NUMBER} was unstable"
+    color = "warning"
   }
   else {
-    slackSend color: "danger", message: "Job: ${env.JOB_NAME} with buildnumber ${env.BUILD_NUMBER} its resulat was unclear"	
+    color = "danger"
   }
+
+// Send notifications
+slackSend color: "${color}", message: "${env.JOB_NAME} on ${branch} branch - ${env.BUILD_RESULT} after ${currentBuild.durationString} and counting (<${env.RUN_DISPLAY_URL}|Open>) (<${env.RUN_CHANGES_DISPLAY_URL}|  Changes>)"
+
 }


### PR DESCRIPTION
The buildresult passed as a parameter is in capitals. However, I would not like our slack messages to contain 'shouting' statuses. Also, there is a need to add an 'Unknown' status for any other non-covered case of result.

Thus, I created a new 'status' variable that takes its value according to the buildresult and is displayed in the slack message.